### PR TITLE
Upgrade to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ outputs:
   version:
     description: 'Flutter version number and build number'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
When I use the get-flutter-version action I get the following warning during the build:

`The following actions uses node12 which is deprecated and will be forced to run on node16: its404/get-flutter-version@v1.0.0. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/`

When run with node16 my build still succeeds and the action produces the correct results. So it seems the only thing needed to stop this warning is to upgrade the version of node used to 16.